### PR TITLE
Only set command name if undefined or 'command'

### DIFF
--- a/packages/apps/terminal/src/core/command.ts
+++ b/packages/apps/terminal/src/core/command.ts
@@ -38,18 +38,18 @@ type Manual = {
 };
 
 export class Command {
-	name: string | undefined;
+	#name?: string;
 	options: Option[] = [];
-	manual: Manual | undefined;
-	requireArgs: boolean | undefined;
-	requireOptions: boolean | undefined;
+	manual?: Manual;
+	requireArgs?: boolean;
+	requireOptions?: boolean;
 
 	execute: Execute = () => {};
 
-	setName(name: string): Command {
-		this.name = name;
+	setName(name?: string): Command {
+		this.#name = name;
 
-		if (!this.manual?.usage) {
+		if (name && !this.manual?.usage) {
 			if (!this.manual)
 				this.manual = {};
 
@@ -57,6 +57,10 @@ export class Command {
 		}
 
 		return this;
+	}
+
+	get name() {
+		return this.#name ?? "";
 	}
 
 	setExecute(execute: Execute): Command {

--- a/packages/apps/terminal/src/core/commands.ts
+++ b/packages/apps/terminal/src/core/commands.ts
@@ -21,8 +21,8 @@ const loadCommands = () => {
 				return;
 
 			if (!command.name) {
-        		command.setName(commandName.toLowerCase());
-      		}
+				command.setName(commandName.toLowerCase());
+			}
 
 			commands.push(command);
 		});
@@ -48,7 +48,7 @@ export class CommandsManager {
 	}
 
 	static search(pattern: string): Command[] {
-		const matches = this.COMMANDS.filter((command) => command.name?.match(pattern));
+		const matches = this.COMMANDS.filter((command) => command.name.match(pattern));
 		return matches;
 	}
 


### PR DESCRIPTION
Allows the default Command object name to be overwritten with the setName() method.